### PR TITLE
Update package.json: Remove warning upon install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ascii-table"
-, "version": "0.0.8"
+, "version": "0.0.9"
 , "license": "MIT"
 , "keywords": [
     "table"
@@ -22,9 +22,6 @@
 , "repository": {
     "type": "git"
   , "url": "git://github.com/sorensen/ascii-table.git"
-  }
-, "engines": {
-    "node": "0.x"
   }
 , "main": "index.js"
 , "scripts": {


### PR DESCRIPTION
The project was locked to requiring `"node": "0.x"`.

As there's no need to depend upon a very old version of Node, I've removed this requirement to solve the warning which always appears when installing:

    npm WARN engine ascii-table@0.0.8: wanted: {"node":"0.x"} (current: {"node":"5.4.0","npm":"3.3.12"})

I also bumped the version number to track this change.