### PR TITLE
Added support for multiline entries in tables

### DIFF
--- a/ascii-table.js
+++ b/ascii-table.js
@@ -37,6 +37,9 @@ function AsciiTable(name, options) {
 AsciiTable.LEFT = 0
 AsciiTable.CENTER = 1
 AsciiTable.RIGHT = 2
+AsciiTable.TOP = 3
+AsciiTable.MIDDLE = 4
+AsciiTable.BOTTOM = 5
 
 /*!
  * Static methods
@@ -64,11 +67,28 @@ AsciiTable.factory = function(name, options) {
  * @api public
  */
 
-AsciiTable.align = function(dir, str, len, pad) {
+AsciiTable.alignHorizontal = function(dir, str, len, pad) {
   if (dir === AsciiTable.LEFT) return AsciiTable.alignLeft(str, len, pad)
   if (dir === AsciiTable.RIGHT) return AsciiTable.alignRight(str, len, pad)
   if (dir === AsciiTable.CENTER) return AsciiTable.alignCenter(str, len, pad)
   return AsciiTable.alignAuto(str, len, pad)
+}
+
+/**
+ * Align the a string at the given length
+ *
+ * @param {Number} direction
+ * @param {String} string input
+ * @param {Number} string length
+ * @param {Number} padding character
+ * @api public
+ * @deprecated
+ */
+
+AsciiTable.align = function(dir, str, len, pad) {
+  console.warn("Use of AsciiTable.align() is deprecated. "
+              + "Please use AsciiTable.alignHorizontal() instead.")
+  return AsciiTable.alignHorizontal(dir, str, len, pad)
 }
 
 /**
@@ -134,7 +154,109 @@ AsciiTable.alignRight = function(str, len, pad) {
 }
 
 /**
- * Auto align string value based on object type
+ * Top align a string by padding it at a given height
+ *
+ * @param {String} str
+ * @param {Number} height
+ * @api public
+ */
+
+AsciiTable.alignTop = function(str, height, asArray) {
+  if (!height || height < 0) return ''
+  if (str === undefined || str === null) str = ''
+  var type = toString.call(str)
+  // If it's a number, make sure not to change it into
+  // a string in the output (if asArray is true)
+  var isNumber = type === "[object Number]"
+  var rows
+  if (asArray && isNumber) {
+    rows = [str]
+  } else {
+    if (typeof str !== 'string') str = str.toString()
+    rows = str.split('\n');
+  }
+  var aheight = height - rows.length
+  if (aheight <= 0) return asArray ? rows : str
+  var out = rows.concat(AsciiTable.arrayFill(aheight, ''))
+  return asArray ? out : out.join('\n')
+}
+
+/**
+ * Center align a string by padding it at a given height
+ *
+ * @param {String} str
+ * @param {Number} string height
+ * @api public
+ */
+
+AsciiTable.alignMiddle = function(str, height, asArray) {
+  if (!height || height < 0) return ''
+  if (str === undefined || str === null) str = ''
+  var type = toString.call(str)
+  // If it's a number, make sure not to change it into
+  // a string in the output (if asArray is true)
+  var isNumber = type === "[object Number]"
+  var rows
+  if (asArray && isNumber) {
+    rows = [str]
+  } else {
+    if (typeof str !== 'string') str = str.toString()
+    rows = str.split('\n');
+  }
+  var aheight = height - rows.length
+  if (aheight <= 0) return asArray ? rows : str
+  var pre = AsciiTable.arrayFill(Math.floor(aheight / 2), '')
+  var post = AsciiTable.arrayFill(Math.ceil(aheight / 2), '')
+  var out = pre.concat(rows).concat(post)
+  return asArray ? out : out.join('\n')
+}
+
+/**
+ * Bottom align a string by padding it at a given height
+ *
+ * @param {String} str
+ * @param {Number} string height
+ * @api public
+ */
+
+AsciiTable.alignBottom = function(str, height, asArray) {
+  if (!height || height < 0) return ''
+  if (str === undefined || str === null) str = ''
+  var type = toString.call(str)
+  // If it's a number, make sure not to change it into
+  // a string in the output (if asArray is true)
+  var isNumber = type === "[object Number]"
+  var rows
+  if (asArray && isNumber) {
+    rows = [str]
+  } else {
+    if (typeof str !== 'string') str = str.toString()
+    rows = str.split('\n');
+  }
+  var aheight = height - rows.length
+  if (aheight <= 0) return asArray ? rows : str
+  var out = AsciiTable.arrayFill(aheight, '').concat(rows)
+  return asArray ? out : out.join('\n')
+}
+
+/**
+ * Auto horizontally-align string value based on object type
+ *
+ * @param {Any} object to string
+ * @param {Number} string length
+ * @param {String} padding character (optional, default '')
+ * @api public
+ * @deprecated
+ */
+
+AsciiTable.alignAuto = function(str, len, pad) {
+  console.warn("Use of AsciiTable.alignAuto() is deprecated. " +
+               "Please use AsciiTable.alignAutoHorizontal() instead.")
+  return AsciiTable.alignAutoHorizontal(str, len, pad)
+}
+
+/**
+ * Auto horizontally-align string value based on object type
  *
  * @param {Any} object to string
  * @param {Number} string length
@@ -142,7 +264,7 @@ AsciiTable.alignRight = function(str, len, pad) {
  * @api public
  */
 
-AsciiTable.alignAuto = function(str, len, pad) {
+AsciiTable.alignAutoHorizontal = function(str, len, pad) {
   if (str === undefined || str === null) str = ''
   var type = toString.call(str)
   pad || (pad = ' ')
@@ -158,6 +280,15 @@ AsciiTable.alignAuto = function(str, len, pad) {
   }
   return str
 }
+
+/**
+ * Auto vertically-align string value based on object type
+ *
+ * @param {Any} object to string
+ * @param {Number} string height
+ * @api public
+ */
+AsciiTable.alignAutoVertical = AsciiTable.alignMiddle;
 
 /**
  * Fill an array at a given size with the given value
@@ -193,11 +324,13 @@ AsciiTable.prototype.clear = function(name) {
   this.__nameAlign = AsciiTable.CENTER
   this.__rows = []
   this.__maxCells = 0
-  this.__aligns = []
+  this.__alignsHorizontal = []
+  this.__alignsVertical = []
   this.__colMaxes = []
   this.__spacing = 1
   this.__heading = null
   this.__headingAlign = AsciiTable.CENTER
+  this.__rowSep = false
   this.setBorder()
 
   if (toString.call(name) === '[object String]') {
@@ -209,16 +342,35 @@ AsciiTable.prototype.clear = function(name) {
 }
 
 /**
+ * Enables visible separators between rows.
+ *
+ * @api public
+ */
+AsciiTable.prototype.enableRowSeparator = function() {
+  this.__rowSep = true;
+}
+
+/**
+ * Disables visible separators between rows.
+ *
+ * @api public
+ */
+AsciiTable.prototype.disableRowSeparator = function() {
+  this.__rowSep = false;
+}
+
+/**
  * Set the table border
  *
  * @param {String} horizontal edges (optional, default `|`)
  * @param {String} vertical edges (optional, default `-`)
  * @param {String} top corners (optional, default `.`)
  * @param {String} bottom corners (optional, default `'`)
+ * @param {String} row rows (if enabled) (optional, default `-`)
  * @api public
  */
 
-AsciiTable.prototype.setBorder = function(edge, fill, top, bottom) {
+AsciiTable.prototype.setBorder = function(edge, fill, top, bottom, row) {
   this.__border = true
   if (arguments.length === 1) {
     fill = top = bottom = edge
@@ -227,6 +379,7 @@ AsciiTable.prototype.setBorder = function(edge, fill, top, bottom) {
   this.__fill = fill || '-'
   this.__top = top || '.'
   this.__bottom = bottom || "'"
+  this.__rowSepStr = row || '-'
   return this
 }
 
@@ -240,20 +393,49 @@ AsciiTable.prototype.removeBorder = function() {
   this.__border = false
   this.__edge = ' '
   this.__fill = ' '
+  this.__rowSepStr = ' '
   return this
 }
 
 /**
- * Set the column alignment at a given index
+ * Set the column horizontal alignment at a given index
  *
  * @param {Number} column index
  * @param {Number} alignment direction
  * @api public
  */
 
-AsciiTable.prototype.setAlign = function(idx, dir) {
-  this.__aligns[idx] = dir
+AsciiTable.prototype.setAlignHorizontal = function(idx, dir) {
+  this.__alignsHorizontal[idx] = dir
   return this
+}
+
+/**
+ * Set the column vertical alignment at a given index
+ *
+ * @param {Number} column index
+ * @param {Number} alignment direction
+ * @api public
+ */
+
+AsciiTable.prototype.setAlignVertical = function(idx, dir) {
+  this.__alignsVertical[idx] = dir
+  return this
+}
+
+/**
+ * Set the column horizontal alignment at a given index
+ *
+ * @param {Number} column index
+ * @param {Number} alignment direction
+ * @api public
+ * @deprecated
+ */
+
+AsciiTable.prototype.setAlign = function(idx, dir) {
+  console.warn("Use of setAlign() is deprecated. " +
+               "Please use setAlignHorizontal() instead.")
+  return this.setAlignHorizontal(idx, dir)
 }
 
 /**
@@ -500,13 +682,18 @@ AsciiTable.prototype.toString = function() {
     , all = this.__heading 
         ? [this.__heading].concat(rows)
         : rows
+    , heights = AsciiTable.arrayFill(all.length, 0)
 
   // Calculate max table cell lengths across all rows
   for (var i = 0; i < all.length; i++) {
     var row = all[i]
     for (var k = 0; k < mLen; k++) {
       var cell = row[k]
-      max[k] = Math.max(max[k], cell ? cell.toString().length : 0)
+        , split = cell ? cell.toString().split('\n') : []
+      for (var j = 0; j < split.length; j++) {
+        max[k] = Math.max(max[k], split[j].length)
+      }
+      heights[i] = Math.max(heights[i], split.length)
     }
   }
   this.__colMaxes = max
@@ -530,7 +717,10 @@ AsciiTable.prototype.toString = function() {
     body.push(this._rowSeperator(mLen, this.__fill))
   }
   for (var i = 0; i < this.__rows.length; i++) {
-    body.push(this._renderRow(this.__rows[i], ' '))
+    body.push(this._renderRow(this.__rows[i], ' ', undefined, heights[(this.__heading ? 1 : 0) + i]))
+    if (this.__rowSep && (i < (this.__rows.length - 1))) {
+      body.push(this._intraRowSeperator())
+    }
   }
   border && body.push(this._seperator(total - mLen + 1, this.__bottom))
 
@@ -564,6 +754,19 @@ AsciiTable.prototype._rowSeperator = function() {
 }
 
 /**
+ * Create a intra-row seperator (this is what is
+ * used when AsciiTable.prototype.__rowSep is enabled)
+ *
+ * @return {String} seperator
+ * @api private
+ */
+
+AsciiTable.prototype._intraRowSeperator = function() {
+  var blanks = AsciiTable.arrayFill(this.__maxCells, this.__rowSepStr)
+  return this._renderRow(blanks, this.__rowSepStr)
+}
+
+/**
  * Render the table title in a centered box
  *
  * @param {Number} string size
@@ -573,44 +776,72 @@ AsciiTable.prototype._rowSeperator = function() {
 
 AsciiTable.prototype._renderTitle = function(len) {
   var name = ' ' + this.__name + ' '
-    , str = AsciiTable.align(this.__nameAlign, name, len - 1, ' ')
+    , str = AsciiTable.alignHorizontal(this.__nameAlign, name, len - 1, ' ')
   return this.__edge + str + this.__edge
 }
 
 /**
- * Render an invdividual row
+ * Render an individual row
  *
  * @param {Array} row
- * @param {String} column seperator
- * @param {Number} total row alignment (optional, default `auto`)
+ * @param {String} str seperator
+ * @param {Number} alignHorizontal horizontal row alignment (optional, default `auto`)
+ * @param {Number} height height of the row
+ * @param {Number} alignVertical vertical row alignment (optional, default `auto`)
  * @return {String} formatted row
  * @api private
  */
 
-AsciiTable.prototype._renderRow = function(row, str, align) {
-  var tmp = ['']
-    , max = this.__colMaxes
+AsciiTable.prototype._renderRow = function(row, str, alignHorizontal, height, alignVertical) {
+  var tmp
+    , maxWidths = this.__colMaxes
+
+  height || (height = 1)
+
+  if (this.__maxCells === 0) {
+    return str + this.__edge
+  }
 
   for (var k = 0; k < this.__maxCells; k++) {
     var cell = row[k]
-      , just = this.__justify ? Math.max.apply(null, max) : max[k]
-      // , pad = k === this.__maxCells - 1 ? just : just + this.__spacing
-      , pad = just
-      , cAlign = this.__aligns[k]
-      , use = align
-      , method = 'alignAuto'
-  
-    if (typeof align === 'undefined') use = cAlign
+      , just = this.__justify ? Math.max.apply(null, maxWidths) : maxWidths[k]
+      , horizontalPad = just
+      , cAlignHorizontal = this.__alignsHorizontal[k]
+      , cAlignVertical = this.__alignsVertical[k]
+      , useVertical = alignVertical
+      , useHorizontal = alignHorizontal
+      , methodVertical = 'alignAutoVertical'
+      , methodHorizontal = 'alignAutoHorizontal'
 
-    if (use === AsciiTable.LEFT) method = 'alignLeft'
-    if (use === AsciiTable.CENTER) method = 'alignCenter'
-    if (use === AsciiTable.RIGHT) method = 'alignRight'
+    if (typeof alignVertical === 'undefined') useVertical = cAlignVertical
 
-    tmp.push(AsciiTable[method](cell, pad, str))
+    if (useVertical === AsciiTable.TOP) methodVertical = 'alignTop'
+    if (useVertical === AsciiTable.MIDDLE) methodVertical = 'alignMiddle'
+    if (useVertical === AsciiTable.BOTTOM) methodVertical = 'alignBottom'
+
+    if (typeof alignHorizontal === 'undefined') useHorizontal = cAlignHorizontal
+
+    if (useHorizontal === AsciiTable.LEFT) methodHorizontal = 'alignLeft'
+    if (useHorizontal === AsciiTable.CENTER) methodHorizontal = 'alignCenter'
+    if (useHorizontal === AsciiTable.RIGHT) methodHorizontal = 'alignRight'
+
+    // Note that all vertically-aligned strings will have the same number of rows
+    var vertAligned = AsciiTable[methodVertical](cell, height, true)
+
+    tmp || (tmp = new Array(vertAligned.length))
+
+    for (var j = 0; j < vertAligned.length; j++) {
+      tmp[j] || (tmp[j] = [''])
+      tmp[j].push(AsciiTable[methodHorizontal](vertAligned[j], horizontalPad, str))
+    }
   }
-  var front = tmp.join(str + this.__edge + str)
-  front = front.substr(1, front.length)
-  return front + str + this.__edge
+  var out = []
+  for (var j = 0; j < tmp.length; j++) {
+    var front = tmp[j].join(str + this.__edge + str)
+    front = front.substr(1, front.length)
+    out.push(front + str + this.__edge)
+  }
+  return out.join('\n')
 }
 
 /*!
@@ -621,13 +852,28 @@ AsciiTable.prototype._renderRow = function(row, str, align) {
 ;['Left', 'Right', 'Center'].forEach(function(dir) {
   var constant = AsciiTable[dir.toUpperCase()]
 
-  ;['setAlign', 'setTitleAlign', 'setHeadingAlign'].forEach(function(method) {
+   AsciiTable.prototype['setAlign' + dir] = function() {
+      var args = slice.call(arguments).concat(constant)
+      return this.setAlignHorizontal.apply(this, args)
+   }
+
+  ;['setTitleAlign', 'setHeadingAlign'].forEach(function(method) {
     // Call the base method with the direction constant as the last argument
     AsciiTable.prototype[method + dir] = function() {
       var args = slice.call(arguments).concat(constant)
       return this[method].apply(this, args)
     }
   })
+})
+
+// Create method shortcuts to all alignment methods for each direction
+;['Top', 'Middle', 'Bottom'].forEach(function(dir) {
+  var constant = AsciiTable[dir.toUpperCase()]
+
+   AsciiTable.prototype['setAlign' + dir] = function() {
+      var args = slice.call(arguments).concat(constant)
+      return this.setAlignVertical.apply(this, args)
+   }
 })
 
 /*!

--- a/test.js
+++ b/test.js
@@ -125,7 +125,7 @@ describe('Ascii Table v' + info.version, function() {
       table
         .setBorder()
         .removeBorder()
-        .setAlign(0, AsciiTable.CENTER)
+        .setAlignHorizontal(0, AsciiTable.CENTER)
         .setAlignLeft(1)
         .setAlignCenter(1)
         .setAlignRight(1)
@@ -169,7 +169,7 @@ describe('Ascii Table v' + info.version, function() {
         .setHeading('', 'Name', 'Age')
         .setHeadingAlign(AsciiTable.RIGHT)
         .setAlignCenter(0)
-        .setAlign(2, AsciiTable.RIGHT)
+        .setAlignHorizontal(2, AsciiTable.RIGHT)
         .addRow('a', 'apple', 'Some longer string')
         .addRow('b', 'banana', 'hi')
         .addRow('c', 'carrot', 'meow')
@@ -188,14 +188,42 @@ describe('Ascii Table v' + info.version, function() {
       + "\n" + "'--------------------------------------'"
       ase(str, table.toString())
     })
+
+    it('multiline', function() {
+      var table = new AsciiTable()
+      table
+        .setTitle('Haikus')
+        .setHeading('Author', 'Haiku')
+        .setAlignCenter(1)
+        .addRow('Basho', 'From time to time\nThe clouds give rest\nTo the moon-beholders.')
+        .addRow('Issa', 'The wren\nEarns his living\nNoiselessly.')
+        .setBorder('|', '=')
+        .enableRowSeparator()
+
+      var str = ""
+             + ".=================================."
+      + "\n" + "|             Haikus              |"
+      + "\n" + "|=================================|"
+      + "\n" + "| Author |         Haiku          |"
+      + "\n" + "|========|========================|"
+      + "\n" + "|        |   From time to time    |"
+      + "\n" + "| Basho  |  The clouds give rest  |"
+      + "\n" + "|        | To the moon-beholders. |"
+      + "\n" + "|--------|------------------------|"
+      + "\n" + "|        |        The wren        |"
+      + "\n" + "| Issa   |    Earns his living    |"
+      + "\n" + "|        |      Noiselessly.      |"
+      + "\n" + "'================================='"
+      ase(table.toString(), str)
+    })
   })
 
   describe('Static methods', function() {
 
     it('#align', function() {
-      ase(AsciiTable.align(AsciiTable.LEFT, 'a', 10), AsciiTable.alignLeft('a', 10))
-      ase(AsciiTable.align(AsciiTable.CENTER, 'a', 10), AsciiTable.alignCenter('a', 10))
-      ase(AsciiTable.align(AsciiTable.RIGHT, 'a', 10), AsciiTable.alignRight('a', 10))
+      ase(AsciiTable.alignHorizontal(AsciiTable.LEFT, 'a', 10), AsciiTable.alignLeft('a', 10))
+      ase(AsciiTable.alignHorizontal(AsciiTable.CENTER, 'a', 10), AsciiTable.alignCenter('a', 10))
+      ase(AsciiTable.alignHorizontal(AsciiTable.RIGHT, 'a', 10), AsciiTable.alignRight('a', 10))
     })
 
     it('#alignLeft', function() {
@@ -300,7 +328,7 @@ describe('Ascii Table v' + info.version, function() {
       
     })
 
-    it('#setAlign', function() {
+    it('#setAlignHorizontal', function() {
       
     })
 


### PR DESCRIPTION
This PR adds support for table rows with multiple lines of data (as mentioned in #20). Note that, given this, automatic line wrapping could easily be added with the use of a package such as `wordwrap`.
